### PR TITLE
Fix admin attendance destroy and cleanup session helper

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,6 +1,6 @@
 class AttendancesController < ApplicationController
   before_action :logged_in_user, only: [:create, :destroy, :update, :edit]
-  before_action :correct_user,   only: [:destroy, :update, :edit]
+  before_action :correct_user,   only: [:update, :edit]
   before_action :admin_user,     only: :destroy
 
   def create
@@ -39,6 +39,7 @@ class AttendancesController < ApplicationController
   end
 
   def destroy
+    @attendance = Attendance.find(params[:id])
     @attendance.destroy
     flash[:success] = "削除しました。"
     redirect_to request.referrer || root_url

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -30,11 +30,6 @@ module SessionsHelper
     !current_user.nil?
   end
 
-  def log_out
-    session.delete(:user_id)
-    @current_user = nil
-  end
-
   def forget(user)
     user.forget
     cookies.delete(:user_id)


### PR DESCRIPTION
## Summary
- allow admins to delete any attendance record
- remove duplicate `log_out` definition

## Testing
- `bundle exec rails test` *(fails: ruby 2.7.4 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d62dd12188332b1addbb52b17d702